### PR TITLE
fix : ensure associated tickets are deleted when user is removed.

### DIFF
--- a/app/Livewire/Categories/ListCategory.php
+++ b/app/Livewire/Categories/ListCategory.php
@@ -17,6 +17,9 @@ class ListCategory extends Component
 
         $name = $category->name;
 
+        // Detach tickets
+        $category->tickets()->detach();
+
         $category->delete();
 
         session()->flash('status', 'Category ' . $name . ' Deleted!');

--- a/app/Livewire/Users/ListUser.php
+++ b/app/Livewire/Users/ListUser.php
@@ -16,7 +16,7 @@ class ListUser extends Component
         $this->authorize('manage', $user);
 
         if (auth()->check() && auth()->user()->id == $user->id) {
-            session()->flash('status', 'You cannot delete your own account.');
+            abort(403, 'You cannot delete your own account');
         }
 
         $name = $user->name;

--- a/app/Livewire/Users/ListUser.php
+++ b/app/Livewire/Users/ListUser.php
@@ -15,6 +15,10 @@ class ListUser extends Component
     {
         $this->authorize('manage', $user);
 
+        if (auth()->check() && auth()->user()->id == $user->id) {
+            session()->flash('status', 'You cannot delete your own account.');
+        }
+
         $name = $user->name;
 
         $user->delete();

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Events\CategoryDeleted;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use App\Events\CategoryDeleted;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
@@ -43,4 +44,9 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
         'password' => 'hashed',
     ];
+
+    public function tickets(): HasMany
+    {
+        return $this->hasMany(Ticket::class);
+    }
 }

--- a/database/migrations/2023_08_03_122558_create_tickets_table.php
+++ b/database/migrations/2023_08_03_122558_create_tickets_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
     {
         Schema::create('tickets', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id')->constrained();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->string('title', 255);
             $table->text('description');
             $table->enum('priority', ['low', 'medium', 'high'])->default('low');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "html",
+    "name": "TicketSupport",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/tests/Feature/User/DeleteUserTest.php
+++ b/tests/Feature/User/DeleteUserTest.php
@@ -2,6 +2,7 @@
 
 use App\Livewire\Users\ListUser;
 use App\Models\User;
+use Illuminate\Support\Facades\Auth;
 use Livewire\Livewire;
 
 beforeEach(function () {
@@ -29,11 +30,15 @@ it('is only allowed to reach this endpoint when logged in as admin', function ()
         ->assertForbidden();
 });
 
+
 it('authenticated user cannot delete their own account', function () {
-    $user = User::factory()->create();
-    login($user);
+    $user = Auth::user();
 
     Livewire::test(ListUser::class)
         ->call('deleteUser', $user)
         ->assertForbidden();
+
+    // Check user
+    $this->assertDatabaseHas('users', ['id' => auth()->id()]);
 });
+

--- a/tests/Feature/User/DeleteUserTest.php
+++ b/tests/Feature/User/DeleteUserTest.php
@@ -30,7 +30,6 @@ it('is only allowed to reach this endpoint when logged in as admin', function ()
         ->assertForbidden();
 });
 
-
 it('authenticated user cannot delete their own account', function () {
     $user = Auth::user();
 
@@ -39,6 +38,20 @@ it('authenticated user cannot delete their own account', function () {
         ->assertForbidden();
 
     // Check user
-    $this->assertDatabaseHas('users', ['id' => auth()->id()]);
+    $this->assertDatabaseHas('users', ['id' => $user->id]);
 });
 
+it('deletes associated tickets when user is deleted', function () {
+    $user = User::factory()->hasTickets(1)->create();
+    $ticketID = $user->tickets()->first()->id;
+
+    expect(User::find($user->id))->not->toBeNull();
+    expect($ticketID)->not->toBeNull();
+
+    $this->assertDatabaseHas('tickets', ['id' => $ticketID]);
+
+    User::find($user->id)->delete();
+
+    expect(User::find($user->id))->toBeNull();
+   $this->assertDatabaseMissing('tickets', ['id' => $ticketID]);
+});

--- a/tests/Feature/User/DeleteUserTest.php
+++ b/tests/Feature/User/DeleteUserTest.php
@@ -2,6 +2,7 @@
 
 use App\Livewire\Users\ListUser;
 use App\Models\User;
+use Livewire\Livewire;
 
 beforeEach(function () {
     login();
@@ -22,6 +23,15 @@ it('is only allowed to reach this endpoint when logged in as admin', function ()
     login(User::factory()->create());
 
     $user = User::factory()->create();
+
+    Livewire::test(ListUser::class)
+        ->call('deleteUser', $user)
+        ->assertForbidden();
+});
+
+it('authenticated user cannot delete their own account', function () {
+    $user = User::factory()->create();
+    login($user);
 
     Livewire::test(ListUser::class)
         ->call('deleteUser', $user)

--- a/tests/Feature/User/DeleteUserTest.php
+++ b/tests/Feature/User/DeleteUserTest.php
@@ -4,6 +4,8 @@ use App\Livewire\Users\ListUser;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Livewire;
+use function Pest\Laravel\assertModelExists;
+use function Pest\Laravel\assertModelMissing;
 
 beforeEach(function () {
     login();
@@ -43,15 +45,15 @@ it('authenticated user cannot delete their own account', function () {
 
 it('deletes associated tickets when user is deleted', function () {
     $user = User::factory()->hasTickets(1)->create();
-    $ticketID = $user->tickets()->first()->id;
+    $ticket = $user->tickets()->first();
 
-    expect(User::find($user->id))->not->toBeNull();
-    expect($ticketID)->not->toBeNull();
+    expect($user)->not->toBeNull();
+    expect($ticket)->not->toBeNull();
 
-    $this->assertDatabaseHas('tickets', ['id' => $ticketID]);
+    assertModelExists($ticket);
 
-    User::find($user->id)->delete();
+    $user->delete();
 
-    expect(User::find($user->id))->toBeNull();
-   $this->assertDatabaseMissing('tickets', ['id' => $ticketID]);
+    expect($user->fresh())->toBeNull();
+    assertModelMissing($ticket);
 });


### PR DESCRIPTION
When deleting, the user gave an error like this:SQLSTATE[23000]: Integrity constraint violation: 1451 Cannot delete or update a parent row: a foreign key constraint fails (`ticket_support`.`tickets`, CONSTRAINT `tickets_user_id_foreign` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`))